### PR TITLE
add configurable dependency sorting

### DIFF
--- a/src/cargo/manifest_writer.rs
+++ b/src/cargo/manifest_writer.rs
@@ -21,11 +21,17 @@ impl Default for ManifestWriter {
 }
 
 impl ManifestWriter {
-  /// Creates a new manifest writer
+  /// Creates a new manifest writer with default settings
   pub fn new() -> Self {
     Self {
       formatter: TomlFormatter::new(),
     }
+  }
+
+  /// Sets whether to sort dependencies when writing manifests
+  pub fn with_dependency_sort(mut self, sort: bool) -> Self {
+    self.formatter.sort_dependencies = sort;
+    self
   }
 
   /// Write unified dependencies to workspace Cargo.toml

--- a/src/commands/unify.rs
+++ b/src/commands/unify.rs
@@ -315,7 +315,12 @@ pub fn run_unify_apply(
     created_backup_id = Some(backup_id);
   }
 
-  let writer = ManifestWriter::new();
+  let sort_mode = ctx
+    .config
+    .as_ref()
+    .map(|c| c.unify.sort_dependencies)
+    .unwrap_or(true);
+  let writer = ManifestWriter::new().with_dependency_sort(sort_mode);
 
   if !plan.workspace_deps.is_empty() {
     progress!("writing [workspace.dependencies]...");

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -140,6 +140,12 @@ pub const SYNCABLE_FIELDS: &[FieldSpec] = &[
     default_toml: "3",
     comment: "Number of backup files to keep (default: 3)",
   },
+  FieldSpec {
+    section: "unify",
+    key: "sort_dependencies",
+    default_toml: "true",
+    comment: "Sort deps alphabetically (default: true)",
+  },
   // =========================================================================
   // [release] section - 10 fields
   // =========================================================================
@@ -270,7 +276,7 @@ mod tests {
   #[test]
   fn test_fields_for_section() {
     let unify_fields: Vec<_> = fields_for_section("unify").collect();
-    assert_eq!(unify_fields.len(), 19); // 16 + detect_undeclared_features + fix_undeclared_features + skip_undeclared_patterns
+    assert_eq!(unify_fields.len(), 20); // 19 + sort_dependencies
     assert!(unify_fields.iter().all(|f| f.section == "unify"));
 
     let release_fields: Vec<_> = fields_for_section("release").collect();
@@ -286,7 +292,7 @@ mod tests {
     // Update this count when adding new fields
     assert_eq!(
       SYNCABLE_FIELDS.len(),
-      30, // 19 unify + 10 release + 1 change-detection
+      31, // 20 unify + 10 release + 1 change-detection
       "Total syncable fields count changed - update this test if intentional"
     );
   }

--- a/src/config/unify.rs
+++ b/src/config/unify.rs
@@ -118,6 +118,11 @@ pub struct UnifyConfig {
   /// These are features that are typically not actionable or are implementation details.
   #[serde(default = "default_skip_undeclared_patterns")]
   pub skip_undeclared_patterns: Vec<String>,
+
+  /// Sort dependencies alphabetically when writing Cargo.toml files (default: true)
+  /// When false, preserves existing order and appends new deps at end.
+  #[serde(default = "default_true")]
+  pub sort_dependencies: bool,
 }
 
 impl Default for UnifyConfig {
@@ -142,6 +147,7 @@ impl Default for UnifyConfig {
       detect_undeclared_features: true,
       fix_undeclared_features: true,
       skip_undeclared_patterns: default_skip_undeclared_patterns(),
+      sort_dependencies: true,
     }
   }
 }
@@ -954,5 +960,42 @@ mod tests {
     assert!(!config.should_skip_undeclared_feature("default"));
     assert!(!config.should_skip_undeclared_feature("std"));
     assert!(!config.should_skip_undeclared_feature("anything"));
+  }
+
+  // ============================================================================
+  // sort_dependencies Tests
+  // ============================================================================
+
+  #[test]
+  fn test_sort_dependencies_default() {
+    let config = UnifyConfig::default();
+    assert!(config.sort_dependencies); // Default is true (alphabetical)
+  }
+
+  #[test]
+  fn test_sort_dependencies_parsing_true() {
+    let toml = r#"sort_dependencies = true"#;
+    let config: UnifyConfig = toml_edit::de::from_str(toml).unwrap();
+    assert!(config.sort_dependencies);
+  }
+
+  #[test]
+  fn test_sort_dependencies_parsing_false() {
+    let toml = r#"sort_dependencies = false"#;
+    let config: UnifyConfig = toml_edit::de::from_str(toml).unwrap();
+    assert!(!config.sort_dependencies);
+  }
+
+  #[test]
+  fn test_sort_dependencies_with_other_options() {
+    let toml = r#"
+      detect_unused = true
+      remove_unused = true
+      sort_dependencies = false
+    "#;
+    let config: UnifyConfig = toml_edit::de::from_str(toml).unwrap();
+    assert!(config.detect_unused);
+    assert!(config.remove_unused);
+    assert!(!config.sort_dependencies);
   }
 }

--- a/src/toml/builder.rs
+++ b/src/toml/builder.rs
@@ -157,6 +157,12 @@ impl RailConfigBuilder {
     }
     content.push_str(&format!("max_backups = {}\n", config.max_backups));
 
+    // === Formatting ===
+    content.push_str(&format!(
+      "sort_dependencies = {}  # false to preserve existing order\n",
+      config.sort_dependencies
+    ));
+
     self.sections.push(format!("[unify]\n{}", content));
 
     self
@@ -253,6 +259,8 @@ impl RailConfigBuilder {
 pub struct WorkspaceDepsBuilder {
   formatter: TomlFormatter,
   deps: Vec<(String, String, Option<String>)>, // Name, Value (formatted), Optional comment
+  /// Whether to sort dependencies alphabetically (default: true)
+  pub sort_dependencies: bool,
 }
 
 impl Default for WorkspaceDepsBuilder {
@@ -260,6 +268,7 @@ impl Default for WorkspaceDepsBuilder {
     Self {
       formatter: TomlFormatter::new(),
       deps: Vec::new(),
+      sort_dependencies: true,
     }
   }
 }
@@ -268,6 +277,13 @@ impl WorkspaceDepsBuilder {
   /// Create a new builder
   pub fn new() -> Self {
     Self::default()
+  }
+
+  /// Set whether to sort dependencies alphabetically (default: true)
+  pub fn with_dependency_sort(mut self, sort: bool) -> Self {
+    self.sort_dependencies = sort;
+    self.formatter.sort_dependencies = sort;
+    self
   }
 
   /// Add dependency
@@ -302,11 +318,15 @@ impl WorkspaceDepsBuilder {
   pub fn build(&self) -> RailResult<String> {
     let mut content = String::from("\n[workspace.dependencies]\n");
 
-    // Sort dependencies
-    let mut sorted_deps = self.deps.clone();
-    sorted_deps.sort_by(|a, b| a.0.cmp(&b.0));
+    let deps_to_write = if self.sort_dependencies {
+      let mut sorted = self.deps.clone();
+      sorted.sort_by(|a, b| a.0.cmp(&b.0));
+      sorted
+    } else {
+      self.deps.clone()
+    };
 
-    for (name, value, comment) in sorted_deps {
+    for (name, value, comment) in deps_to_write {
       if let Some(c) = comment {
         content.push_str(&format!("{} = {}  # {}\n", name, value, c));
       } else {

--- a/src/toml/format.rs
+++ b/src/toml/format.rs
@@ -15,6 +15,8 @@ pub struct TomlFormatter {
   pub inline_feature_threshold: usize,
   /// Indentation string (usually 2 spaces)
   pub indent: &'static str,
+  /// Whether to sort dependencies alphabetically (true) or preserve order (false)
+  pub sort_dependencies: bool,
 }
 
 impl Default for TomlFormatter {
@@ -23,6 +25,7 @@ impl Default for TomlFormatter {
       inline_array_threshold: 4,
       inline_feature_threshold: 10,
       indent: "  ",
+      sort_dependencies: true,
     }
   }
 }
@@ -158,11 +161,11 @@ impl TomlFormatter {
   /// Format a Cargo.toml document in-place
   ///
   /// Applies standard formatting rules:
-  /// 1. Sorts dependencies
+  /// 1. Sorts dependencies (if dependency_sort is Alphabetical)
   /// 2. Standardizes table format (inline vs block)
   pub fn format_manifest(&self, doc: &mut DocumentMut) -> RailResult<()> {
-    // 1. Sort dependencies alphabetically
-    self.sort_dependencies(doc);
+    // 1. Sort dependencies (only if configured to sort alphabetically)
+    self.sort_deps(doc);
 
     // 2. Standardize table formatting (inline vs block)
     self.standardize_tables(doc);
@@ -171,7 +174,15 @@ impl TomlFormatter {
   }
 
   /// Sort dependencies in all dependency sections
-  fn sort_dependencies(&self, doc: &mut DocumentMut) {
+  ///
+  /// Only sorts if `sort_dependencies` is true.
+  /// When false, existing order is maintained.
+  fn sort_deps(&self, doc: &mut DocumentMut) {
+    // Skip sorting if configured to preserve existing order
+    if !self.sort_dependencies {
+      return;
+    }
+
     let sections = [
       "dependencies",
       "dev-dependencies",


### PR DESCRIPTION
Adds a sort_dependencies flag to the 'unify' section.

Wasn't sure if I should add to the `WorkspaceDepsBuilder` since it seems to be only used in tests atm. Also used builder-style methods since you seem to prefer default constructors, let me know if you'd prefer `sort_dependencies` to be passed directly to `::new()` instead.

closes #4 