### PR TITLE
Release 7715775e

### DIFF
--- a/.changes/added-cargo-ready-planner-7771.md
+++ b/.changes/added-cargo-ready-planner-7771.md
@@ -1,5 +1,0 @@
----
-"cargo-rail" = "minor"
----
-
-Added Cargo-ready planner scope args, automation-safe change status output, and a commit-time change-file coverage check.

--- a/.changes/changed-public-library-contracts-8cf4.md
+++ b/.changes/changed-public-library-contracts-8cf4.md
@@ -1,5 +1,0 @@
----
-"cargo-rail" = "minor"
----
-
-Changed public Rust APIs for mutation contracts, release execution, split/sync safety, and test-runner selection; downstream library users must update constructors and method calls.

--- a/.changes/completed-machine-contracts.md
+++ b/.changes/completed-machine-contracts.md
@@ -1,5 +1,0 @@
----
-"cargo-rail" = "minor"
----
-
-Made command output formats exact, published the planner v3 JSON Schema, and added checkout-independent plan identities.

--- a/.changes/curated-release-history-9496.md
+++ b/.changes/curated-release-history-9496.md
@@ -1,5 +1,0 @@
----
-"cargo-rail" = "patch"
----
-
-Curated the historical changelog and required reviewed release intent for future releases.

--- a/.changes/fixed-mutation-boundaries-a91c.md
+++ b/.changes/fixed-mutation-boundaries-a91c.md
@@ -1,5 +1,0 @@
----
-"cargo-rail" = "minor"
----
-
-Bounded release, split, and sync mutations to approved repository paths, made sync conflicts resumable, and preserved exact split history and mappings.

--- a/.changes/fixed-non-publishable-preflight-adbc.md
+++ b/.changes/fixed-non-publishable-preflight-adbc.md
@@ -1,5 +1,0 @@
----
-"cargo-rail" = "patch"
----
-
-Skipped crates.io preflight checks when every crate in a release plan has publishing disabled.

--- a/.changes/fixed-release-and-test-runner-contracts.md
+++ b/.changes/fixed-release-and-test-runner-contracts.md
@@ -1,5 +1,0 @@
----
-"cargo-rail" = "minor"
----
-
-Made releases resumable, verified and distributed the exact tagged commit, and made Cargo, nextest, filter, and test-harness arguments backend-correct.

--- a/.changes/fixed-windows-path-contracts.md
+++ b/.changes/fixed-windows-path-contracts.md
@@ -1,5 +1,0 @@
----
-"cargo-rail" = "patch"
----
-
-Fixed Windows path normalization for release, split, sync, and portable planner identities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.16.0](https://github.com/loadingalias/cargo-rail/compare/v0.15.0...v0.16.0) - 2026-07-11
+
+- Added Cargo-ready planner scope args, automation-safe change status output, and a commit-time change-file coverage check.
+
+- Changed public Rust APIs for mutation contracts, release execution, split/sync safety, and test-runner selection; downstream library users must update constructors and method calls.
+
+- Made command output formats exact, published the planner v3 JSON Schema, and added checkout-independent plan identities.
+
+- Curated the historical changelog and required reviewed release intent for future releases.
+
+- Bounded release, split, and sync mutations to approved repository paths, made sync conflicts resumable, and preserved exact split history and mappings.
+
+- Skipped crates.io preflight checks when every crate in a release plan has publishing disabled.
+
+- Made releases resumable, verified and distributed the exact tagged commit, and made Cargo, nextest, filter, and test-harness arguments backend-correct.
+
+- Fixed Windows path normalization for release, split, sync, and portable planner identities.
+
+### Features
+
+- **workspace**: make control-plane operations verifiable and recoverable ([6bd64fb](https://github.com/loadingalias/cargo-rail/commit/6bd64fb6f028bee13a372ff23d4f4b789a5562b3))
+
+### Bug Fixes
+
+- **release**: harden release readiness and curate history ([3679801](https://github.com/loadingalias/cargo-rail/commit/367980186587210735bbecf9a7b6e3485cf2985b))
+- **git**: normalize Windows paths at repository boundaries ([7936232](https://github.com/loadingalias/cargo-rail/commit/793623232c23e25d2f92734ca673421052c40b4a))
+
+### Documentation
+
+- **release**: record v0.16 library API breaks ([3595b4f](https://github.com/loadingalias/cargo-rail/commit/3595b4f1f4c0e6c4f89f4b66688a597bbad0f61b))
+
+
+
 This file records user-visible changes. Git tags and [GitHub Releases](https://github.com/loadingalias/cargo-rail/releases) retain the complete release history.
 
 ## [0.15.0](https://github.com/loadingalias/cargo-rail/compare/v0.14.0...v0.15.0) - 2026-07-06

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-rail"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-rail"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 rust-version = { workspace = true }
 license = "MIT"


### PR DESCRIPTION
📦 Release Plan

1. cargo-rail
   Version: 0.15.0 → 0.16.0
   Bump: 0.15.0 -> 0.16.0 (auto: cargo-semver-checks escalated to major)
   Tag: ✗ (--skip-tag)
   Publish: ✗ (--skip-publish)
   Causes: 3679801 (patch), 7936232 (patch), 6bd64fb (minor)

Summary: 1 crate(s), 0 to publish, 0 tag(s), 0 skipped

## Changelog Bodies

### cargo-rail v0.16.0

- Added Cargo-ready planner scope args, automation-safe change status output, and a commit-time change-file coverage check.

- Changed public Rust APIs for mutation contracts, release execution, split/sync safety, and test-runner selection; downstream library users must update constructors and method calls.

- Made command output formats exact, published the planner v3 JSON Schema, and added checkout-independent plan identities.

- Curated the historical changelog and required reviewed release intent for future releases.

- Bounded release, split, and sync mutations to approved repository paths, made sync conflicts resumable, and preserved exact split history and mappings.

- Skipped crates.io preflight checks when every crate in a release plan has publishing disabled.

- Made releases resumable, verified and distributed the exact tagged commit, and made Cargo, nextest, filter, and test-harness arguments backend-correct.

- Fixed Windows path normalization for release, split, sync, and portable planner identities.

### Features

- **workspace**: make control-plane operations verifiable and recoverable ([6bd64fb](https://github.com/loadingalias/cargo-rail/commit/6bd64fb6f028bee13a372ff23d4f4b789a5562b3))

### Bug Fixes

- **release**: harden release readiness and curate history ([3679801](https://github.com/loadingalias/cargo-rail/commit/367980186587210735bbecf9a7b6e3485cf2985b))
- **git**: normalize Windows paths at repository boundaries ([7936232](https://github.com/loadingalias/cargo-rail/commit/793623232c23e25d2f92734ca673421052c40b4a))

### Documentation

- **release**: record v0.16 library API breaks ([3595b4f](https://github.com/loadingalias/cargo-rail/commit/3595b4f1f4c0e6c4f89f4b66688a597bbad0f61b))

