### PR TITLE
Release 08318c2a

### DIFF
--- a/.changes/current-dependencies-actions-7d25.md
+++ b/.changes/current-dependencies-actions-7d25.md
@@ -1,8 +1,0 @@
----
-"cargo-rail" = "patch"
----
-
-Raised the repository and package toolchain to Rust 1.97.1, updated Rust dependencies, the native-cache fixture
-dependency graph, GitHub Actions, the CI planner's cargo-rail version, and the native-cache comparator's sccache
-installation to their current releases. Release rebuilds now use the exact package toolchain, immutable assets are
-verified instead of overwritten, and action verification binds every workflow pin to the action lock.

--- a/.changes/fix-git-batch-pipe-deadlock-537e.md
+++ b/.changes/fix-git-batch-pipe-deadlock-537e.md
@@ -1,5 +1,0 @@
----
-"cargo-rail" = "patch"
----
-
-Prevented bulk Git object reads from deadlocking when request and response pipes fill.

--- a/.changes/mutation-boundaries-0728.md
+++ b/.changes/mutation-boundaries-0728.md
@@ -1,8 +1,0 @@
----
-"cargo-rail" = "major"
----
-
-Hardened backup, release, split, and sync mutation boundaries against path escape, symlink traversal, cross-operation
-plan reuse, and exact-release checkout drift. Split and sync check modes now distinguish clean state from pending work,
-configuration validation rejects malformed unify globs and empty split branches, and release checks report skipped
-evidence separately from passed checks.

--- a/.changes/native-cache-x64-windows-7d25.md
+++ b/.changes/native-cache-x64-windows-7d25.md
@@ -1,7 +1,0 @@
----
-"cargo-rail" = "minor"
----
-
-Added exact generated native-cache capability authority and `cargo rail doctor native-cache`, kept uncertified hosts on
-stable fail-closed bypasses, hardened Windows cache boundaries against reparse points and transient reader conflicts,
-and preserved Cargo's workspace path spelling so Windows compiler outputs remain byte-exact.

--- a/.changes/p0-support-matrix-0726.md
+++ b/.changes/p0-support-matrix-0726.md
@@ -1,6 +1,0 @@
----
-"cargo-rail" = "minor"
----
-
-Published one generated execution, cache, and performance support matrix, added continuous full-suite CI for all six
-advertised native host/architecture pairs, and added macOS x86-64 plus required Linux musl release inventories.

--- a/.changes/rail-identity-0728.md
+++ b/.changes/rail-identity-0728.md
@@ -1,7 +1,0 @@
----
-"cargo-rail" = "minor"
----
-
-Presented the `cargo-rail` crate and CLI as Cargo-Rail, the Rust workspace engine, and aligned the README, CLI help,
-package metadata, and public documentation around its shared Cargo and Git decision model without renaming technical
-interfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@
 
 
 
+
+## [0.20.0](https://github.com/loadingalias/cargo-rail/compare/v0.19.1...v0.20.0) - 2026-07-29
+
+- Raised the repository and package toolchain to Rust 1.97.1, updated Rust dependencies, the native-cache fixture
+  dependency graph, GitHub Actions, the CI planner's cargo-rail version, and the native-cache comparator's sccache
+  installation to their current releases. Release rebuilds now use the exact package toolchain, immutable assets are
+  verified instead of overwritten, and action verification binds every workflow pin to the action lock.
+
+- Prevented bulk Git object reads from deadlocking when request and response pipes fill.
+
+- Hardened backup, release, split, and sync mutation boundaries against path escape, symlink traversal, cross-operation
+  plan reuse, and exact-release checkout drift. Split and sync check modes now distinguish clean state from pending work,
+  configuration validation rejects malformed unify globs and empty split branches, and release checks report skipped
+  evidence separately from passed checks.
+
+- Added exact generated native-cache capability authority and `cargo rail doctor native-cache`, kept uncertified hosts on
+  stable fail-closed bypasses, hardened Windows cache boundaries against reparse points and transient reader conflicts,
+  and preserved Cargo's workspace path spelling so Windows compiler outputs remain byte-exact.
+
+- Published one generated execution, cache, and performance support matrix, added continuous full-suite CI for all six
+  advertised native host/architecture pairs, and added macOS x86-64 plus required Linux musl release inventories.
+
+- Presented the `cargo-rail` crate and CLI as Cargo-Rail, the Rust workspace engine, and aligned the README, CLI help,
+  package metadata, and public documentation around its shared Cargo and Git decision model without renaming technical
+  interfaces.
+
+
 ## [0.19.1](https://github.com/loadingalias/cargo-rail/compare/v0.19.0...v0.19.1) - 2026-07-25
 
 - Hardened exact-SHA release readiness to reject all-skipped GitHub rollups and run release commits through normal CI. `cargo rail config migrate` now removes the inert `release.require_clean` and `release.publish_delay` fields, and release previews no longer claim to delay between publishes. Added explicit cache capability and evaluation guidance.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-rail"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-rail"
-version = "0.19.1"
+version = "0.20.0"
 edition = "2024"
 rust-version = { workspace = true }
 license = "MIT"


### PR DESCRIPTION
📦 Release Plan

1. cargo-rail
   Version: 0.19.1 → 0.20.0
   Bump: auto: reviewed change files → major
   Tag: deferred until finalization
   Publish: deferred until finalization

## Changelog Bodies

### cargo-rail v0.20.0

- Raised the repository and package toolchain to Rust 1.97.1, updated Rust dependencies, the native-cache fixture
  dependency graph, GitHub Actions, the CI planner's cargo-rail version, and the native-cache comparator's sccache
  installation to their current releases. Release rebuilds now use the exact package toolchain, immutable assets are
  verified instead of overwritten, and action verification binds every workflow pin to the action lock.

- Prevented bulk Git object reads from deadlocking when request and response pipes fill.

- Hardened backup, release, split, and sync mutation boundaries against path escape, symlink traversal, cross-operation
  plan reuse, and exact-release checkout drift. Split and sync check modes now distinguish clean state from pending work,
  configuration validation rejects malformed unify globs and empty split branches, and release checks report skipped
  evidence separately from passed checks.

- Added exact generated native-cache capability authority and `cargo rail doctor native-cache`, kept uncertified hosts on
  stable fail-closed bypasses, hardened Windows cache boundaries against reparse points and transient reader conflicts,
  and preserved Cargo's workspace path spelling so Windows compiler outputs remain byte-exact.

- Published one generated execution, cache, and performance support matrix, added continuous full-suite CI for all six
  advertised native host/architecture pairs, and added macOS x86-64 plus required Linux musl release inventories.

- Presented the `cargo-rail` crate and CLI as Cargo-Rail, the Rust workspace engine, and aligned the README, CLI help,
  package metadata, and public documentation around its shared Cargo and Git decision model without renaming technical
  interfaces.
