### PR TITLE
fix(release): validate GitHub remote identity

### DIFF
--- a/.changes/fix-github-remote-parsing.md
+++ b/.changes/fix-github-remote-parsing.md
@@ -1,0 +1,5 @@
+---
+"cargo-rail" = "patch"
+---
+
+Fixed GitHub repository detection for remote URLs with a trailing slash, and rejected non-repository paths before they could produce incorrect changelog or release links.

--- a/src/release/changelog/mod.rs
+++ b/src/release/changelog/mod.rs
@@ -430,7 +430,8 @@ pub fn detect_github_repo(workspace_root: &Path) -> Option<(String, String)> {
 
 /// Parse a GitHub remote URL into (org, repo)
 fn parse_github_remote(url: &str) -> Option<(String, String)> {
-  let trimmed = url.trim().trim_end_matches(".git").trim_end_matches('/');
+  let trimmed = url.trim().trim_end_matches('/');
+  let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
 
   let repo_part = if let Some(ssh) = trimmed.strip_prefix("git@github.com:") {
     ssh
@@ -440,9 +441,10 @@ fn parse_github_remote(url: &str) -> Option<(String, String)> {
     trimmed.strip_prefix("https://github.com/")?
   };
 
-  let mut parts = repo_part.split('/');
-  let org = parts.next()?;
-  let repo = parts.next()?;
+  let (org, repo) = repo_part.split_once('/')?;
+  if org.is_empty() || repo.is_empty() || repo.contains('/') || org.contains(['?', '#']) || repo.contains(['?', '#']) {
+    return None;
+  }
 
   Some((org.to_string(), repo.to_string()))
 }
@@ -708,7 +710,20 @@ mod tests {
       parse_github_remote("ssh://git@github.com/org/repo"),
       Some(("org".to_string(), "repo".to_string()))
     );
+    assert_eq!(
+      parse_github_remote("https://github.com/org/repo.git/"),
+      Some(("org".to_string(), "repo".to_string()))
+    );
     assert_eq!(parse_github_remote("git@gitlab.com:org/repo.git"), None);
+  }
+
+  #[test]
+  fn parse_github_remote_rejects_non_repository_paths() {
+    assert_eq!(parse_github_remote("https://github.com/org/repo/issues"), None);
+    assert_eq!(parse_github_remote("https://github.com//repo.git"), None);
+    assert_eq!(parse_github_remote("https://github.com/org/.git"), None);
+    assert_eq!(parse_github_remote("https://github.com/org/repo?tab=readme"), None);
+    assert_eq!(parse_github_remote("https://github.com/org/repo#readme"), None);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- normalize trailing slashes before removing the optional `.git` suffix from GitHub remotes
- reject empty identities, extra path segments, queries, and fragments instead of deriving a misleading repository
- add regression tests and a patch-level release change file

## Why

Automatic repository detection feeds changelog links and exact-SHA GitHub release readiness. A remote such as `https://github.com/org/repo.git/` was previously parsed as repository `repo.git`, while a non-repository path such as `https://github.com/org/repo/issues` was silently accepted as `org/repo`.

## Compatibility

The existing HTTPS, SCP-like SSH, and `ssh://` forms remain supported. URLs with extra non-repository path/query/fragment data now fail closed, allowing the existing no-auto-link fallback to apply.

## Verification

- red/green regression run: `cargo +stable test --ignore-rust-version --lib parse_github_remote`
- `cargo +stable fmt --all -- --check`
- `cargo +stable clippy --ignore-rust-version --all-targets --all-features -- -D warnings`
- `cargo +stable doc --ignore-rust-version --workspace --no-deps --all-features --locked` with `RUSTDOCFLAGS=-D warnings`
- `cargo +stable deny check all`
- `cargo +stable audit --no-fetch`
- `cargo +stable nextest run --workspace -P default --all-features --locked --config-file .config/nextest.toml --ignore-rust-version`

The local host has Rust 1.93.1, so the MSRV gate was explicitly bypassed for local code-path testing. The repository's Rust 1.95 compatibility matrix remains authoritative. The Windows nextest run completed the full inventory but reported host/resource-specific failures detailed in the PR check results; the changed parser tests passed.
